### PR TITLE
Do not attempt to create '.' directory in upload

### DIFF
--- a/lib/commands/upload_cmds/sources.js
+++ b/lib/commands/upload_cmds/sources.js
@@ -50,13 +50,15 @@ module.exports = {
     for (const file of argv.files) {
       process.stdout.write(`- ${file.source}...`);
       const fileDir = path.dirname(file.source);
-      createdDirs = await checkDirExists(
-        API,
-        createdDirs,
-        fileDir,
-        branch,
-        info,
-      );
+      if (fileDir !== '.') {
+        createdDirs = await checkDirExists(
+          API,
+          createdDirs,
+          fileDir,
+          branch,
+          info,
+        );
+      }
 
       await uploadFile(API, file, branch, info);
       console.log(chalk.green('OK'));


### PR DESCRIPTION
Adds a check around upload directory creation to prevent it from creating a '.' directory.

Closes #27.