### PR TITLE
Don't touch Git if a branch is specified

### DIFF
--- a/lib/commands/upload_cmds/sources.js
+++ b/lib/commands/upload_cmds/sources.js
@@ -50,13 +50,15 @@ module.exports = {
     for (const file of argv.files) {
       process.stdout.write(`- ${file.source}...`);
       const fileDir = path.dirname(file.source);
-      createdDirs = await checkDirExists(
-        API,
-        createdDirs,
-        fileDir,
-        branch,
-        info,
-      );
+      if (fileDir !== '.') {
+        createdDirs = await checkDirExists(
+          API,
+          createdDirs,
+          fileDir,
+          branch,
+          info,
+        );
+      }
 
       await uploadFile(API, file, branch, info);
       console.log(chalk.green('OK'));

--- a/lib/utils/getCrowdinBranch.js
+++ b/lib/utils/getCrowdinBranch.js
@@ -4,15 +4,12 @@ const getBasePath = require('./getBasePath');
 
 module.exports = async function getCrowdinBranch(argv) {
   const { baseBranches, branch } = argv;
-  const projectBranch = await gitBranch(path.dirname(getBasePath(argv)));
 
-  return new Promise((resolve) => {
-    const targetBranch = branch || projectBranch;
+  const targetBranch = branch || await gitBranch(path.dirname(getBasePath(argv)));
 
-    if (!targetBranch || baseBranches.includes(targetBranch)) {
-      resolve(undefined);
-    } else {
-      resolve(targetBranch.replace(/\//g, '_'));
-    }
-  });
+  if (targetBranch && !baseBranches.includes(targetBranch)) {
+    return targetBranch.replace(/\//g, '_');
+  } else {
+    return undefined;
+  }
 };


### PR DESCRIPTION
Right now the current Git branch is retrieved even when a branch is manually supplied on the command line. This causes an error if you're not inside of Git repository. This PR fixes that by only checking the Git branch when it's actually needed.

Also removes the promise used in an async context because it's redundant.

Builds upon #28 because I'm using these fixes. Merge it first or cherry-pick the right commit here.