### PR TITLE
Trigger machine translation on upload

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -150,6 +150,26 @@ module.exports = (argv) => ({
     return apiCall(argv, 'export', { branch });
   },
 
+  async preTranslate(engine, languages, files, branch) {
+    // Crowdin API does not support a branch argument so we add it to the file
+    // paths instead.
+    const fileSources = files.map(
+      (file) => (branch ? `${branch}/${file.source}` : file.source),
+    );
+
+    return dryApiCall(
+      argv,
+      'pre-translate',
+      {},
+      {
+        method: 'mt',
+        engine,
+        'languages[]': languages,
+        'files[]': fileSources,
+      },
+    );
+  },
+
   getDownloadTranslationUrl(branch, language, file) {
     return getUri(argv.projectIdentifier, 'export-file', {
       key: argv.apiKey,

--- a/lib/commands/upload_cmds/sources.js
+++ b/lib/commands/upload_cmds/sources.js
@@ -64,7 +64,11 @@ module.exports = {
       console.log(chalk.green('OK'));
     }
 
-    if (argv.preTranslationEngine && argv.preTranslationLanguages) {
+    if (
+        argv.preTranslationEngine &&
+        argv.preTranslationLanguages &&
+        argv.preTranslationLanguages.length > 0
+    ) {
       process.stdout.write(
         `Pre-translating ${argv.preTranslationLanguages.join(', ')} with ${argv.preTranslationEngine} engine...`
       );

--- a/lib/commands/upload_cmds/sources.js
+++ b/lib/commands/upload_cmds/sources.js
@@ -63,6 +63,19 @@ module.exports = {
       await uploadFile(API, file, branch, info);
       console.log(chalk.green('OK'));
     }
+
+    if (argv.preTranslationEngine && argv.preTranslationLanguages) {
+      process.stdout.write(
+        `Pre-translating ${argv.preTranslationLanguages.join(', ')} with ${argv.preTranslationEngine} engine...`
+      );
+      await API.preTranslate(
+        argv.preTranslationEngine,
+        argv.preTranslationLanguages,
+        argv.files,
+        branch,
+      );
+      console.log(chalk.green('OK'));
+    }
     /* eslint-enable */
   },
 };

--- a/lib/commands/upload_cmds/sources.js
+++ b/lib/commands/upload_cmds/sources.js
@@ -50,13 +50,15 @@ module.exports = {
     for (const file of argv.files) {
       process.stdout.write(`- ${file.source}...`);
       const fileDir = path.dirname(file.source);
-      createdDirs = await checkDirExists(
-        API,
-        createdDirs,
-        fileDir,
-        branch,
-        info,
-      );
+      if (fileDir !== '.') {
+        createdDirs = await checkDirExists(
+          API,
+          createdDirs,
+          fileDir,
+          branch,
+          info,
+        );
+      }
 
       await uploadFile(API, file, branch, info);
       console.log(chalk.green('OK'));

--- a/lib/utils/getCrowdinBranch.js
+++ b/lib/utils/getCrowdinBranch.js
@@ -4,15 +4,12 @@ const getBasePath = require('./getBasePath');
 
 module.exports = async function getCrowdinBranch(argv) {
   const { baseBranches, branch } = argv;
-  const projectBranch = await gitBranch(path.dirname(getBasePath(argv)));
 
-  return new Promise((resolve) => {
-    const targetBranch = branch || projectBranch;
+  const targetBranch = branch || await gitBranch(path.dirname(getBasePath(argv)));
 
-    if (!targetBranch || baseBranches.includes(targetBranch)) {
-      resolve(undefined);
-    } else {
-      resolve(targetBranch.replace(/\//g, '_'));
-    }
-  });
+  if (targetBranch && !baseBranches.includes(targetBranch)) {
+    return targetBranch.replace(/\//g, '_');
+  } else {
+    return undefined;
+  }
 };


### PR DESCRIPTION
Adds the config options `pre_translation_engine` and `pre_translation_languages` that will together trigger machine pre-translation on upload of source files.

E.g.:

```yaml
pre_translation_engine: google
pre_translation_languages: ['nl', 'en-GB']
```

Builds upon PRs #28 and #29.